### PR TITLE
Clarify action_space_mapping remove unused var

### DIFF
--- a/blog/how_to_write_a_customized_environment/notebook.jl
+++ b/blog/how_to_write_a_customized_environment/notebook.jl
@@ -224,7 +224,7 @@ wrapped_env = ActionTransformedEnv(
         env,
         s -> s ? 1 : 2
     ),
-    action_space_mapping = x -> Base.OneTo(3),
+    action_space_mapping = _ -> Base.OneTo(3),
     action_mapping = i -> action_space(env)[i]
 )
 


### PR DESCRIPTION
Remove unused `x` variable, which I think makes this easier to understand.